### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,8 @@
 
 name: build
 on: [pull_request, push]
+permissions:
+  contents: read
 
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/Onako2/redirect-players/security/code-scanning/1](https://github.com/Onako2/redirect-players/security/code-scanning/1)

To fix the issue, add a `permissions` block to the workflow file. This block should specify the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are appropriate:
- `contents: read` for reading repository contents during the checkout step.
- `contents: write` for uploading build artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the specific job (`build`) to limit its scope.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
